### PR TITLE
Version 4.4.6 en devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM espressif/idf:v4.4.5
+FROM espressif/idf:v4.4.6
 
 ARG DEBIAN_FRONTEND=nointeractive
 ARG CONTAINER_USER=esp


### PR DESCRIPTION
Actualizada la version de Espressif IDF a la version 4.4.6 en la generación del contenedor de desarrollo